### PR TITLE
Scale pixmap height if needed

### DIFF
--- a/src/imagelayer.cpp
+++ b/src/imagelayer.cpp
@@ -234,6 +234,10 @@ void ImageLayer::updateTiles()
 
     // TODO create enums to define image aspect, auto tile, etc...
     QPixmap pixmap(source()); // TODO
+    // If item height doesn't match pixmap height, scaleToHeight
+    if (pixmap.height() != (int)height()) {
+        pixmap = pixmap.scaledToHeight(height()); 
+    }
 
     if (m_drawType == Quasi::PlaneDrawType) {
         m_tileWidth = width();


### PR DESCRIPTION
If the ImageLayer height isn't the same as the pixmap height, scale the pixmap height to match.  The source image should attempt to accomidate for the desired height to ensure the quality of the scaled pixmap, but when the exact height isn't known we should scale instead of crashing.
