### PR TITLE
ScriptBehavior fix

### DIFF
--- a/src/scriptbehavior.cpp
+++ b/src/scriptbehavior.cpp
@@ -44,14 +44,12 @@ QQmlScriptString ScriptBehavior::script() const
 
 void ScriptBehavior::setScript(const QQmlScriptString &script)
 {
-    if (m_script.stringLiteral() != script.stringLiteral()) {
-        m_script = script;
+    m_script = script;
 
-        if (m_expression)
-            delete m_expression;
+    if (m_expression)
+        delete m_expression;
 
-        m_expression = new QQmlExpression(m_script);
+    m_expression = new QQmlExpression(m_script);
 
-        emit scriptChanged();
-    }
+    emit scriptChanged();
 }


### PR DESCRIPTION
Don't compare QQmlScriptString before setting it.  There seems to be a bug in Qt when getting the scriptString from QML that breaks comparison.  Setting it does actually work though.  This fixes
issue #22.
